### PR TITLE
Translate Maxmind Download Urls to Match Ingress-Nginx Expectations.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	CacheDuration time.Duration
 
 	DebugAddr string
+
+	TranslateIngressNginxPaths bool
 }
 
 func NewDefault() *Config {

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -51,5 +51,5 @@ func (c *Config) RegisterFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&c.DebugAddr, FlagDebugAddr, c.DebugAddr, "Debug pprof listen address")
 
-	cmd.Flags().BoolVarP(&c.TranslateIngressNginxPaths, FlagTranslateIngressNginxUrls, "", false, "Whether to translate Ingress-Nginx's expected file names to Maxmind paths.")
+	cmd.Flags().BoolVarP(&c.TranslateIngressNginxPaths, FlagTranslateIngressNginxUrls, "", true, "Automatically translate ingress-nginx's expected file names to Maxmind paths.")
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -25,6 +25,8 @@ const (
 	FlagCacheDuration = "cache-duration"
 
 	FlagDebugAddr = "debug-addr"
+
+	FlagTranslateIngressNginxUrls = "translate-ingress-nginx-urls"
 )
 
 func (c *Config) RegisterFlags(cmd *cobra.Command) {
@@ -48,4 +50,6 @@ func (c *Config) RegisterFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(&c.CacheDuration, FlagCacheDuration, c.CacheDuration, "Length of time to cache MaxMind response")
 
 	cmd.Flags().StringVar(&c.DebugAddr, FlagDebugAddr, c.DebugAddr, "Debug pprof listen address")
+
+	cmd.Flags().BoolVarP(&c.TranslateIngressNginxPaths, FlagTranslateIngressNginxUrls, "", false, "Whether to translate Ingress-Nginx's expected file names to Maxmind paths.")
 }

--- a/internal/server/handlers/proxy/proxy.go
+++ b/internal/server/handlers/proxy/proxy.go
@@ -102,7 +102,7 @@ func upstreamURL(host string, r *http.Request, translatePaths bool) url.URL {
 
 		matches := pat.FindStringSubmatch(u.Path)
 		if len(matches) > 1 {
-			newPath := fmt.Sprintf("%s/dowload?suffix=tar.gz", matches[1])
+			newPath := fmt.Sprintf("%s/download?suffix=tar.gz", matches[1])
 			log.Debug().Msg(fmt.Sprintf("translating %s into %s", u.Path, newPath))
 			u.Path = newPath
 		}

--- a/internal/server/handlers/proxy/proxy.go
+++ b/internal/server/handlers/proxy/proxy.go
@@ -102,9 +102,10 @@ func upstreamURL(host string, r *http.Request, translatePaths bool) url.URL {
 
 		matches := pat.FindStringSubmatch(u.Path)
 		if len(matches) > 1 {
-			newPath := fmt.Sprintf("%s/download?suffix=tar.gz", matches[1])
+			newPath := fmt.Sprintf("%s/download", matches[1])
 			log.Debug().Msg(fmt.Sprintf("translating %s into %s", u.Path, newPath))
 			u.Path = newPath
+			u.RawQuery = "suffix=tar.gz"
 		}
 	}
 

--- a/internal/server/handlers/proxy/proxy_test.go
+++ b/internal/server/handlers/proxy/proxy_test.go
@@ -1,0 +1,51 @@
+package proxy
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestUpstreamUrl(t *testing.T) {
+	inputs := []struct {
+		name      string
+		url       string
+		translate bool
+		expected  string
+	}{
+		{
+			"maxmind download untranslated",
+			"https://download.maxmind.com/geoip/databases/GeoLite2-Country.tar.gz",
+			false,
+			"https://download.maxmind.com/geoip/databases/GeoLite2-Country.tar.gz",
+		},
+		{
+			"maxmind download translated",
+			"https://download.maxmind.com/geoip/databases/GeoLite2-Country.tar.gz",
+			true,
+			"https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz",
+		},
+	}
+
+	for _, tc := range inputs {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := url.Parse(tc.url)
+			if err != nil {
+				t.Errorf("Unparseable url: %q: %s", tc.url, err)
+			}
+
+			host := u.Host
+			req, err := http.NewRequest(http.MethodGet, tc.url, nil)
+			if err != nil {
+				t.Errorf("failed creating http request to %q: %s", tc.url, err)
+			}
+
+			actual := upstreamURL(host, req, tc.translate)
+
+			assert.Equal(t, tc.expected, actual.String(), "upstreamUrl does not meet expectations")
+
+		})
+	}
+
+}


### PR DESCRIPTION
Ingress-nginx will download Maxmind db's from a mirror if configured with --maxmind-mirror=<mirror URL>.

It is not, however flexible enough to handle the query string required by Maxmind's download URL's as of 2024.

This change introduces a flag that, if set to 'true', will translate a path from what ingress-nginx expects to what Maxmind serves as of 2024. 

from: https://download.maxmind.com/geoip/databases/GeoLite2-Country.tar.gz

to: https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz